### PR TITLE
allow haskell-src-exts-1.19

### DIFF
--- a/haskell-src-exts-simple.cabal
+++ b/haskell-src-exts-simple.cabal
@@ -39,6 +39,6 @@ library
         ScopedTypeVariables
     build-depends:
         base >= 4.7 && < 5,
-        haskell-src-exts >= 1.18 && < 1.19
+        haskell-src-exts >= 1.18 && < 1.20
     hs-source-dirs:      src
     default-language:    Haskell2010


### PR DESCRIPTION
I tested and it seems to build fine with `haskell-src-exts-1.19`.