### PR TITLE
Bump the dependency on `base`

### DIFF
--- a/haskell-src-exts-simple.cabal
+++ b/haskell-src-exts-simple.cabal
@@ -38,7 +38,7 @@ library
         PatternSynonyms,
         ScopedTypeVariables
     build-depends:
-        base >= 4.7 && < 5,
+        base >= 4.9 && < 5,
         haskell-src-exts >= 1.21 && < 1.22
     hs-source-dirs:      src
     default-language:    Haskell2010


### PR DESCRIPTION
The latest version of `haskell-src-exts-simple` doesn't build with GHC < 8:

```
Building library for haskell-src-exts-simple-1.21.1.0.. 
src/Language/Haskell/Exts/Simple/Fixity.hs:19:8: 
    Could not find module ‘Control.Monad.Fail’ 
    It is a member of the hidden package ‘fail-4.9.0.0@9VfzPgZmVnyGDICixWHnyA’. 
    Perhaps you need to add ‘fail’ to the build-depends in your .cabal file. 
    Use -v to see a list of the files searched for. 
```

Would be nice if you also made a Hackage revision with the same change.

Alternatively, you may want to add a dependency on `fail` instead of applying this patch, but there may be further errors.