### PR TITLE
Add COMPLETE pragmas for pattern synonyms

### DIFF
--- a/src/Language/Haskell/Exts/Simple/Parser.hs
+++ b/src/Language/Haskell/Exts/Simple/Parser.hs
@@ -34,17 +34,33 @@ pattern ListOf a <- H.ListOf _ a
 listOf :: [a] -> ListOf a
 listOf a = H.ListOf H.noSrcSpan a
 
+#if MIN_VERSION_GLASGOW_HASKELL(8,2,1,0)
+{-# COMPLETE ListOf #-}
+#endif
+
 -- ** `H.PragmasAndModuleName`
 type PragmasAndModuleName = H.PragmasAndModuleName ()
 pattern PragmasAndModuleName a b = H.PragmasAndModuleName () (a :: [ModulePragma]) (b :: Maybe ModuleName) :: PragmasAndModuleName
+
+#if MIN_VERSION_GLASGOW_HASKELL(8,2,1,0)
+{-# COMPLETE PragmasAndModuleName #-}
+#endif
 
 -- ** `H.PragmasAndModuleHead`
 type PragmasAndModuleHead = H.PragmasAndModuleHead ()
 pattern PragmasAndModuleHead a b = H.PragmasAndModuleHead () (a :: [ModulePragma]) (b :: Maybe ModuleHead)
 
+#if MIN_VERSION_GLASGOW_HASKELL(8,2,1,0)
+{-# COMPLETE PragmasAndModuleHead #-}
+#endif
+
 -- ** `H.ModuleHeadAndImports`
 type ModuleHeadAndImports = H.ModuleHeadAndImports ()
 pattern ModuleHeadAndImports a b c = H.ModuleHeadAndImports () (a :: [ModulePragma]) (b :: Maybe ModuleHead) (c :: [ImportDecl])
+
+#if MIN_VERSION_GLASGOW_HASKELL(8,2,1,0)
+{-# COMPLETE ModuleHeadAndImports #-}
+#endif
 
 -- * Functions
 

--- a/src/Language/Haskell/Exts/Simple/Syntax.hs
+++ b/src/Language/Haskell/Exts/Simple/Syntax.hs
@@ -30,6 +30,10 @@ import Language.Haskell.Exts.Syntax (
 type ModuleName = H.ModuleName ()
 pattern ModuleName a = H.ModuleName () (a :: String) :: ModuleName
 
+#if MIN_VERSION_GLASGOW_HASKELL(8,2,1,0)
+{-# COMPLETE ModuleName #-}
+#endif
+
 -- ** `H.SpecialCon`
 type SpecialCon = H.SpecialCon ()
 pattern UnitCon = H.UnitCon () :: SpecialCon
@@ -40,36 +44,64 @@ pattern Cons = H.Cons () :: SpecialCon
 pattern UnboxedSingleCon = H.UnboxedSingleCon () :: SpecialCon
 pattern ExprHole = H.ExprHole () :: SpecialCon
 
+#if MIN_VERSION_GLASGOW_HASKELL(8,2,1,0)
+{-# COMPLETE UnitCon, ListCon, FunCon, TupleCon, Cons, UnboxedSingleCon, ExprHole #-}
+#endif
+
 -- ** `H.QName`
 type QName = H.QName ()
 pattern Qual a b = H.Qual () (a :: ModuleName) (b :: Name) :: QName
 pattern UnQual a = H.UnQual () (a :: Name) :: QName
 pattern Special a = H.Special () (a :: SpecialCon) :: QName
 
+#if MIN_VERSION_GLASGOW_HASKELL(8,2,1,0)
+{-# COMPLETE Qual, UnQual, Special #-}
+#endif
+
 -- ** `H.Name`
 type Name = H.Name ()
 pattern Ident a = H.Ident () (a :: String) :: Name
 pattern Symbol a = H.Symbol () (a :: String) :: Name
+
+#if MIN_VERSION_GLASGOW_HASKELL(8,2,1,0)
+{-# COMPLETE Ident, Symbol #-}
+#endif
 
 -- ** `H.IPName`
 type IPName = H.IPName ()
 pattern IPDup a = H.IPDup () (a :: String) :: IPName
 pattern IPLin a = H.IPLin () (a :: String) :: IPName
 
+#if MIN_VERSION_GLASGOW_HASKELL(8,2,1,0)
+{-# COMPLETE IPDup, IPLin #-}
+#endif
+
 -- ** `H.QOp`
 type QOp = H.QOp ()
 pattern QVarOp a = H.QVarOp () (a :: QName) :: QOp
 pattern QConOp a = H.QConOp () (a :: QName) :: QOp
+
+#if MIN_VERSION_GLASGOW_HASKELL(8,2,1,0)
+{-# COMPLETE QVarOp, QConOp #-}
+#endif
 
 -- ** `H.Op`
 type Op = H.Op ()
 pattern VarOp a = H.VarOp () (a :: Name) :: Op
 pattern ConOp a = H.ConOp () (a :: Name) :: Op
 
+#if MIN_VERSION_GLASGOW_HASKELL(8,2,1,0)
+{-# COMPLETE VarOp, ConOp #-}
+#endif
+
 -- ** `H.CName`
 type CName = H.CName ()
 pattern VarName a = H.VarName () (a :: Name) :: CName
 pattern ConName a = H.ConName () (a :: Name) :: CName
+
+#if MIN_VERSION_GLASGOW_HASKELL(8,2,1,0)
+{-# COMPLETE VarName, ConName #-}
+#endif
 
 -- ** `H.Module`
 type Module = H.Module ()
@@ -77,13 +109,25 @@ pattern Module a b c d = H.Module () (a :: (Maybe ModuleHead)) (b :: [ModulePrag
 pattern XmlPage a b c d e f = H.XmlPage () (a :: ModuleName) (b :: [ModulePragma]) (c :: XName) (d :: [XAttr]) (e :: (Maybe Exp)) (f :: [Exp]) :: Module
 pattern XmlHybrid a b c d e f g h = H.XmlHybrid () (a :: (Maybe ModuleHead)) (b :: [ModulePragma]) (c :: [ImportDecl]) (d :: [Decl]) (e :: XName) (f :: [XAttr]) (g :: (Maybe Exp)) (h :: [Exp]) :: Module
 
+#if MIN_VERSION_GLASGOW_HASKELL(8,2,1,0)
+{-# COMPLETE Module, XmlPage, XmlHybrid #-}
+#endif
+
 -- ** `H.ModuleHead`
 type ModuleHead = H.ModuleHead ()
 pattern ModuleHead a b c = H.ModuleHead () (a :: ModuleName) (b :: (Maybe WarningText)) (c :: (Maybe ExportSpecList)) :: ModuleHead
 
+#if MIN_VERSION_GLASGOW_HASKELL(8,2,1,0)
+{-# COMPLETE ModuleHead #-}
+#endif
+
 -- ** `H.ExportSpecList`
 type ExportSpecList = H.ExportSpecList ()
 pattern ExportSpecList a = H.ExportSpecList () (a :: [ExportSpec]) :: ExportSpecList
+
+#if MIN_VERSION_GLASGOW_HASKELL(8,2,1,0)
+{-# COMPLETE ExportSpecList #-}
+#endif
 
 -- ** `H.ExportSpec`
 type ExportSpec = H.ExportSpec ()
@@ -92,10 +136,18 @@ pattern EAbs a b = H.EAbs () (a :: Namespace) (b :: QName) :: ExportSpec
 pattern EThingWith a b c = H.EThingWith () (a :: EWildcard) (b :: QName) (c :: [CName]) :: ExportSpec
 pattern EModuleContents a = H.EModuleContents () (a :: ModuleName) :: ExportSpec
 
+#if MIN_VERSION_GLASGOW_HASKELL(8,2,1,0)
+{-# COMPLETE EVar, EAbs, EThingWith, EModuleContents #-}
+#endif
+
 -- ** `H.EWildcard`
 type EWildcard = H.EWildcard ()
 pattern NoWildcard = H.NoWildcard () :: EWildcard
 pattern EWildcard a = H.EWildcard () (a :: Int) :: EWildcard
+
+#if MIN_VERSION_GLASGOW_HASKELL(8,2,1,0)
+{-# COMPLETE NoWildcard, EWildcard #-}
+#endif
 
 -- ** `H.Namespace`
 type Namespace = H.Namespace ()
@@ -103,14 +155,26 @@ pattern NoNamespace = H.NoNamespace () :: Namespace
 pattern TypeNamespace = H.TypeNamespace () :: Namespace
 pattern PatternNamespace = H.PatternNamespace () :: Namespace
 
+#if MIN_VERSION_GLASGOW_HASKELL(8,2,1,0)
+{-# COMPLETE NoNamespace, TypeNamespace, PatternNamespace #-}
+#endif
+
 -- ** `H.ImportDecl`
 type ImportDecl = H.ImportDecl ()
 pattern ImportDecl { importModule, importQualified, importSrc, importSafe, importPkg, importAs, importSpecs } =
     H.ImportDecl () importModule importQualified importSrc importSafe importPkg importAs importSpecs :: ImportDecl
 
+#if MIN_VERSION_GLASGOW_HASKELL(8,2,1,0)
+{-# COMPLETE ImportDecl #-}
+#endif
+
 -- ** `H.ImportSpecList`
 type ImportSpecList = H.ImportSpecList ()
 pattern ImportSpecList a b = H.ImportSpecList () (a :: Bool) (b :: [ImportSpec]) :: ImportSpecList
+
+#if MIN_VERSION_GLASGOW_HASKELL(8,2,1,0)
+{-# COMPLETE ImportSpecList #-}
+#endif
 
 -- ** `H.ImportSpec`
 type ImportSpec = H.ImportSpec ()
@@ -119,11 +183,19 @@ pattern IAbs a b = H.IAbs () (a :: Namespace) (b :: Name) :: ImportSpec
 pattern IThingAll a = H.IThingAll () (a :: Name) :: ImportSpec
 pattern IThingWith a b = H.IThingWith () (a :: Name) (b :: [CName]) :: ImportSpec
 
+#if MIN_VERSION_GLASGOW_HASKELL(8,2,1,0)
+{-# COMPLETE IVar, IAbs, IThingAll, IThingWith #-}
+#endif
+
 -- ** `H.Assoc`
 type Assoc = H.Assoc ()
 pattern AssocNone = H.AssocNone () :: Assoc
 pattern AssocLeft = H.AssocLeft () :: Assoc
 pattern AssocRight = H.AssocRight () :: Assoc
+
+#if MIN_VERSION_GLASGOW_HASKELL(8,2,1,0)
+{-# COMPLETE AssocNone, AssocLeft, AssocRight #-}
+#endif
 
 -- ** `H.Decl`
 type Decl = H.Decl ()
@@ -163,21 +235,43 @@ pattern MinimalPragma a = H.MinimalPragma () (a :: (Maybe BooleanFormula)) :: De
 pattern RoleAnnotDecl a b = H.RoleAnnotDecl () (a :: QName) (b :: [Role]) :: Decl
 pattern CompletePragma a b = H.CompletePragma () (a :: [Name]) (b :: (Maybe QName)) :: Decl
 
+#if MIN_VERSION_GLASGOW_HASKELL(8,2,1,0)
+{-# COMPLETE TypeDecl, TypeFamDecl, ClosedTypeFamDecl, DataDecl, GDataDecl,
+             DataFamDecl, TypeInsDecl, DataInsDecl, GDataInsDecl, ClassDecl, InstDecl,
+             DerivDecl, InfixDecl, DefaultDecl, SpliceDecl, TSpliceDecl, TypeSig,
+             PatSynSig, FunBind, PatBind, PatSyn, ForImp, ForExp, RulePragmaDecl,
+             DeprPragmaDecl, WarnPragmaDecl, InlineSig, InlineConlikeSig, SpecSig,
+             SpecInlineSig, InstSig, AnnPragma, MinimalPragma, RoleAnnotDecl,
+             CompletePragma #-}
+#endif
+
 -- ** `H.PatternSynDirection`
 type PatternSynDirection = H.PatternSynDirection ()
 pattern Unidirectional = H.Unidirectional :: PatternSynDirection
 pattern ImplicitBidirectional = H.ImplicitBidirectional :: PatternSynDirection
 pattern ExplicitBidirectional a = H.ExplicitBidirectional () (a :: [Decl]) :: PatternSynDirection
 
+#if MIN_VERSION_GLASGOW_HASKELL(8,2,1,0)
+{-# COMPLETE Unidirectional, ImplicitBidirectional, ExplicitBidirectional #-}
+#endif
+
 -- ** `H.TypeEqn`
 type TypeEqn = H.TypeEqn ()
 pattern TypeEqn a b = H.TypeEqn () (a :: Type) (b :: Type) :: TypeEqn
+
+#if MIN_VERSION_GLASGOW_HASKELL(8,2,1,0)
+{-# COMPLETE TypeEqn #-}
+#endif
 
 -- ** `H.Annotation`
 type Annotation = H.Annotation ()
 pattern Ann a b = H.Ann () (a :: Name) (b :: Exp) :: Annotation
 pattern TypeAnn a b = H.TypeAnn () (a :: Name) (b :: Exp) :: Annotation
 pattern ModuleAnn a = H.ModuleAnn () (a :: Exp) :: Annotation
+
+#if MIN_VERSION_GLASGOW_HASKELL(8,2,1,0)
+{-# COMPLETE Ann, TypeAnn, ModuleAnn #-}
+#endif
 
 -- ** `H.BooleanFormula`
 type BooleanFormula = H.BooleanFormula ()
@@ -186,6 +280,10 @@ pattern AndFormula a = H.AndFormula () (a :: [BooleanFormula]) :: BooleanFormula
 pattern OrFormula a = H.OrFormula () (a :: [BooleanFormula]) :: BooleanFormula
 pattern ParenFormula a = H.ParenFormula () (a :: BooleanFormula) :: BooleanFormula
 
+#if MIN_VERSION_GLASGOW_HASKELL(8,2,1,0)
+{-# COMPLETE VarFormula, AndFormula, OrFormula, ParenFormula #-}
+#endif
+
 -- ** `H.Role`
 type Role = H.Role ()
 pattern Nominal = H.Nominal () :: Role
@@ -193,19 +291,35 @@ pattern Representational = H.Representational () :: Role
 pattern Phantom = H.Phantom () :: Role
 pattern RoleWildcard = H.RoleWildcard () :: Role
 
+#if MIN_VERSION_GLASGOW_HASKELL(8,2,1,0)
+{-# COMPLETE Nominal, Representational, Phantom, RoleWildcard #-}
+#endif
+
 -- ** `H.DataOrNew`
 type DataOrNew = H.DataOrNew ()
 pattern DataType = H.DataType () :: DataOrNew
 pattern NewType = H.NewType () :: DataOrNew
 
+#if MIN_VERSION_GLASGOW_HASKELL(8,2,1,0)
+{-# COMPLETE DataType, NewType #-}
+#endif
+
 -- ** `H.InjectivityInfo`
 type InjectivityInfo = H.InjectivityInfo ()
 pattern InjectivityInfo a b = H.InjectivityInfo () (a :: Name) (b :: [Name]) :: InjectivityInfo
+
+#if MIN_VERSION_GLASGOW_HASKELL(8,2,1,0)
+{-# COMPLETE InjectivityInfo #-}
+#endif
 
 -- ** `H.ResultSig`
 type ResultSig = H.ResultSig ()
 pattern KindSig a = H.KindSig () (a :: Kind) :: ResultSig
 pattern TyVarSig a = H.TyVarSig () (a :: TyVarBind) :: ResultSig
+
+#if MIN_VERSION_GLASGOW_HASKELL(8,2,1,0)
+{-# COMPLETE KindSig, TyVarSig #-}
+#endif
 
 -- ** `H.DeclHead`
 type DeclHead = H.DeclHead ()
@@ -214,10 +328,18 @@ pattern DHInfix a b = H.DHInfix () (a :: TyVarBind) (b :: Name) :: DeclHead
 pattern DHParen a = H.DHParen () (a :: DeclHead) :: DeclHead
 pattern DHApp a b = H.DHApp () (a :: DeclHead) (b :: TyVarBind) :: DeclHead
 
+#if MIN_VERSION_GLASGOW_HASKELL(8,2,1,0)
+{-# COMPLETE DHead, DHInfix, DHParen, DHApp #-}
+#endif
+
 -- ** `H.InstRule`
 type InstRule = H.InstRule ()
 pattern IRule a b c = H.IRule () (a :: (Maybe [TyVarBind])) (b :: (Maybe Context)) (c :: InstHead) :: InstRule
 pattern IParen a = H.IParen () (a :: InstRule) :: InstRule
+
+#if MIN_VERSION_GLASGOW_HASKELL(8,2,1,0)
+{-# COMPLETE IRule, IParen #-}
+#endif
 
 -- ** `H.InstHead`
 type InstHead = H.InstHead ()
@@ -226,9 +348,17 @@ pattern IHInfix a b = H.IHInfix () (a :: Type) (b :: QName) :: InstHead
 pattern IHParen a = H.IHParen () (a :: InstHead) :: InstHead
 pattern IHApp a b = H.IHApp () (a :: InstHead) (b :: Type) :: InstHead
 
+#if MIN_VERSION_GLASGOW_HASKELL(8,2,1,0)
+{-# COMPLETE IHCon, IHInfix, IHParen, IHApp #-}
+#endif
+
 -- ** `H.Deriving`
 type Deriving = H.Deriving ()
 pattern Deriving a b = H.Deriving () (a :: (Maybe DerivStrategy)) (b :: [InstRule]) :: Deriving
+
+#if MIN_VERSION_GLASGOW_HASKELL(8,2,1,0)
+{-# COMPLETE Deriving #-}
+#endif
 
 -- ** `H.DerivStrategy`
 type DerivStrategy = H.DerivStrategy ()
@@ -237,23 +367,43 @@ pattern DerivAnyclass = H.DerivAnyclass () :: DerivStrategy
 pattern DerivNewtype = H.DerivNewtype () :: DerivStrategy
 pattern DerivVia a = H.DerivVia () (a :: Type) :: DerivStrategy
 
+#if MIN_VERSION_GLASGOW_HASKELL(8,2,1,0)
+{-# COMPLETE DerivStock, DerivAnyclass, DerivNewtype, DerivVia #-}
+#endif
+
 -- ** `H.Binds`
 type Binds = H.Binds ()
 pattern BDecls a = H.BDecls () (a :: [Decl]) :: Binds
 pattern IPBinds a = H.IPBinds () (a :: [IPBind]) :: Binds
 
+#if MIN_VERSION_GLASGOW_HASKELL(8,2,1,0)
+{-# COMPLETE BDecls, IPBinds #-}
+#endif
+
 -- ** `H.IPBind`
 type IPBind = H.IPBind ()
 pattern IPBind a b = H.IPBind () (a :: IPName) (b :: Exp) :: IPBind
+
+#if MIN_VERSION_GLASGOW_HASKELL(8,2,1,0)
+{-# COMPLETE IPBind #-}
+#endif
 
 -- ** `H.Match`
 type Match = H.Match ()
 pattern Match a b c d = H.Match () (a :: Name) (b :: [Pat]) (c :: Rhs) (d :: (Maybe Binds)) :: Match
 pattern InfixMatch a b c d e = H.InfixMatch () (a :: Pat) (b :: Name) (c :: [Pat]) (d :: Rhs) (e :: (Maybe Binds)) :: Match
 
+#if MIN_VERSION_GLASGOW_HASKELL(8,2,1,0)
+{-# COMPLETE Match, InfixMatch #-}
+#endif
+
 -- ** `H.QualConDecl`
 type QualConDecl = H.QualConDecl ()
 pattern QualConDecl a b c = H.QualConDecl () (a :: (Maybe [TyVarBind])) (b :: (Maybe Context)) (c :: ConDecl) :: QualConDecl
+
+#if MIN_VERSION_GLASGOW_HASKELL(8,2,1,0)
+{-# COMPLETE QualConDecl #-}
+#endif
 
 -- ** `H.ConDecl`
 type ConDecl = H.ConDecl ()
@@ -261,13 +411,25 @@ pattern ConDecl a b = H.ConDecl () (a :: Name) (b :: [Type]) :: ConDecl
 pattern InfixConDecl a b c = H.InfixConDecl () (a :: Type) (b :: Name) (c :: Type) :: ConDecl
 pattern RecDecl a b = H.RecDecl () (a :: Name) (b :: [FieldDecl]) :: ConDecl
 
+#if MIN_VERSION_GLASGOW_HASKELL(8,2,1,0)
+{-# COMPLETE ConDecl, InfixConDecl, RecDecl #-}
+#endif
+
 -- ** `H.FieldDecl`
 type FieldDecl = H.FieldDecl ()
 pattern FieldDecl a b = H.FieldDecl () (a :: [Name]) (b :: Type) :: FieldDecl
 
+#if MIN_VERSION_GLASGOW_HASKELL(8,2,1,0)
+{-# COMPLETE FieldDecl #-}
+#endif
+
 -- ** `H.GadtDecl`
 type GadtDecl = H.GadtDecl ()
 pattern GadtDecl a b c d e = H.GadtDecl () (a :: Name) (b :: (Maybe [TyVarBind])) (c :: (Maybe Context)) (d :: (Maybe [FieldDecl])) (e :: Type) :: GadtDecl
+
+#if MIN_VERSION_GLASGOW_HASKELL(8,2,1,0)
+{-# COMPLETE GadtDecl #-}
+#endif
 
 -- ** `H.ClassDecl`
 type ClassDecl = H.ClassDecl ()
@@ -277,6 +439,10 @@ pattern ClsTyFam a b c = H.ClsTyFam () (a :: DeclHead) (b :: (Maybe ResultSig)) 
 pattern ClsTyDef a = H.ClsTyDef () (a :: TypeEqn) :: ClassDecl
 pattern ClsDefSig a b = H.ClsDefSig () (a :: Name) (b :: Type) :: ClassDecl
 
+#if MIN_VERSION_GLASGOW_HASKELL(8,2,1,0)
+{-# COMPLETE ClsDecl, ClsDataFam, ClsTyFam, ClsTyDef, ClsDefSig #-}
+#endif
+
 -- ** `H.InstDecl`
 type InstDecl = H.InstDecl ()
 pattern InsDecl a = H.InsDecl () (a :: Decl) :: InstDecl
@@ -284,11 +450,19 @@ pattern InsType a b = H.InsType () (a :: Type) (b :: Type) :: InstDecl
 pattern InsData a b c d = H.InsData () (a :: DataOrNew) (b :: Type) (c :: [QualConDecl]) (d :: [Deriving]) :: InstDecl
 pattern InsGData a b c d e = H.InsGData () (a :: DataOrNew) (b :: Type) (c :: (Maybe Kind)) (d :: [GadtDecl]) (e :: [Deriving]) :: InstDecl
 
+#if MIN_VERSION_GLASGOW_HASKELL(8,2,1,0)
+{-# COMPLETE InsDecl, InsType, InsData, InsGData #-}
+#endif
+
 -- ** `H.BangType`
 type BangType = H.BangType ()
 pattern BangedTy = H.BangedTy () :: BangType
 pattern LazyTy = H.LazyTy () :: BangType
 pattern NoStrictAnnot = H.NoStrictAnnot () :: BangType
+
+#if MIN_VERSION_GLASGOW_HASKELL(8,2,1,0)
+{-# COMPLETE BangedTy, LazyTy, NoStrictAnnot #-}
+#endif
 
 -- ** `H.Unpackedness`
 type Unpackedness = H.Unpackedness ()
@@ -296,14 +470,26 @@ pattern Unpack = H.Unpack () :: Unpackedness
 pattern NoUnpack = H.NoUnpack () :: Unpackedness
 pattern NoUnpackPragma = H.NoUnpackPragma () :: Unpackedness
 
+#if MIN_VERSION_GLASGOW_HASKELL(8,2,1,0)
+{-# COMPLETE Unpack, NoUnpack, NoUnpackPragma #-}
+#endif
+
 -- ** `H.Rhs`
 type Rhs = H.Rhs ()
 pattern UnGuardedRhs a = H.UnGuardedRhs () (a :: Exp) :: Rhs
 pattern GuardedRhss a = H.GuardedRhss () (a :: [GuardedRhs]) :: Rhs
 
+#if MIN_VERSION_GLASGOW_HASKELL(8,2,1,0)
+{-# COMPLETE UnGuardedRhs, GuardedRhss #-}
+#endif
+
 -- ** `H.GuardedRhs`
 type GuardedRhs = H.GuardedRhs ()
 pattern GuardedRhs a b = H.GuardedRhs () (a :: [Stmt]) (b :: Exp) :: GuardedRhs
+
+#if MIN_VERSION_GLASGOW_HASKELL(8,2,1,0)
+{-# COMPLETE GuardedRhs #-}
+#endif
 
 -- ** `H.Type`
 type Type = H.Type ()
@@ -327,10 +513,20 @@ pattern TyBang a b c = H.TyBang () (a :: BangType) (b :: Unpackedness) (c :: Typ
 pattern TyWildCard a = H.TyWildCard () (a :: (Maybe Name)) :: Type
 pattern TyQuasiQuote a b = H.TyQuasiQuote () (a :: String) (b :: String) :: Type
 
+#if MIN_VERSION_GLASGOW_HASKELL(8,2,1,0)
+{-# COMPLETE TyForall, TyStar, TyFun, TyTuple, TyUnboxedSum, TyList, TyParArray, TyApp,
+             TyVar, TyCon, TyParen, TyInfix, TyKind, TyPromoted, TyEquals, TySplice,
+             TyBang, TyWildCard, TyQuasiQuote #-}
+#endif
+
 -- ** `H.MaybePromotedName`
 type MaybePromotedName = H.MaybePromotedName ()
 pattern PromotedName a = H.PromotedName () (a :: QName) :: MaybePromotedName
 pattern UnpromotedName a = H.UnpromotedName () (a :: QName) :: MaybePromotedName
+
+#if MIN_VERSION_GLASGOW_HASKELL(8,2,1,0)
+{-# COMPLETE PromotedName, UnpromotedName #-}
+#endif
 
 -- ** `H.Promoted`
 type Promoted = H.Promoted ()
@@ -341,12 +537,21 @@ pattern PromotedList a b = H.PromotedList () (a :: Bool) (b :: [Type]) :: Promot
 pattern PromotedTuple a = H.PromotedTuple () (a :: [Type]) :: Promoted
 pattern PromotedUnit = H.PromotedUnit () :: Promoted
 
+#if MIN_VERSION_GLASGOW_HASKELL(8,2,1,0)
+{-# COMPLETE PromotedInteger, PromotedString, PromotedCon, PromotedList, PromotedTuple,
+             PromotedUnit #-}
+#endif
+
 -- skipped: data Boxed
 
 -- ** `H.TyVarBind`
 type TyVarBind = H.TyVarBind ()
 pattern KindedVar a b = H.KindedVar () (a :: Name) (b :: Kind) :: TyVarBind
 pattern UnkindedVar a = H.UnkindedVar () (a :: Name) :: TyVarBind
+
+#if MIN_VERSION_GLASGOW_HASKELL(8,2,1,0)
+{-# COMPLETE KindedVar, UnkindedVar #-}
+#endif
 
 -- ** `H.Kind`
 
@@ -357,17 +562,29 @@ type Kind = H.Kind ()
 type FunDep = H.FunDep ()
 pattern FunDep a b = H.FunDep () (a :: [Name]) (b :: [Name]) :: FunDep
 
+#if MIN_VERSION_GLASGOW_HASKELL(8,2,1,0)
+{-# COMPLETE FunDep #-}
+#endif
+
 -- ** `H.Context`
 type Context = H.Context ()
 pattern CxSingle a = H.CxSingle () (a :: Asst) :: Context
 pattern CxTuple a = H.CxTuple () (a :: [Asst]) :: Context
 pattern CxEmpty = H.CxEmpty () :: Context
 
+#if MIN_VERSION_GLASGOW_HASKELL(8,2,1,0)
+{-# COMPLETE CxSingle, CxTuple, CxEmpty #-}
+#endif
+
 -- ** `H.Asst`
 type Asst = H.Asst ()
 pattern TypeA a = H.TypeA () (a :: Type) :: Asst
 pattern IParam a b = H.IParam () (a :: IPName) (b :: Type) :: Asst
 pattern ParenA a = H.ParenA () (a :: Asst) :: Asst
+
+#if MIN_VERSION_GLASGOW_HASKELL(8,2,1,0)
+{-# COMPLETE TypeA, IParam, ParenA #-}
+#endif
 
 -- ** `H.Literal`
 type Literal = H.Literal ()
@@ -424,10 +641,19 @@ primStringL a = H.PrimString () a a
 
 #undef where
 
+#if MIN_VERSION_GLASGOW_HASKELL(8,2,1,0)
+{-# COMPLETE Char, String, Int, Frac, PrimInt, PrimWord, PrimFloat, PrimDouble,
+             PrimChar, PrimString #-}
+#endif
+
 -- ** `H.Sign`
 type Sign = H.Sign ()
 pattern Signless = H.Signless () :: Sign
 pattern Negative = H.Negative () :: Sign
+
+#if MIN_VERSION_GLASGOW_HASKELL(8,2,1,0)
+{-# COMPLETE Signless, Negative #-}
+#endif
 
 -- ** `H.Exp`
 type Exp = H.Exp ()
@@ -488,14 +714,33 @@ pattern RightArrHighApp a b = H.RightArrHighApp () (a :: Exp) (b :: Exp) :: Exp
 pattern ArrOp a = H.ArrOp () (a :: Exp) :: Exp
 pattern LCase a = H.LCase () (a :: [Alt]) :: Exp
 
+#if MIN_VERSION_GLASGOW_HASKELL(8,2,1,0)
+{-# COMPLETE Var, OverloadedLabel, IPVar, Con, Lit, InfixApp, App, NegApp, Lambda, Let,
+             If, MultiIf, Case, Do, MDo, Tuple, UnboxedSum, TupleSection, List,
+             ParArray, Paren, LeftSection, RightSection, RecConstr, RecUpdate,
+             EnumFrom, EnumFromTo, EnumFromThen, EnumFromThenTo, ParArrayFromTo,
+             ParArrayFromThenTo, ListComp, ParComp, ParArrayComp, ExpTypeSig, VarQuote,
+             TypQuote, BracketExp, SpliceExp, QuasiQuote, TypeApp, XTag, XETag,
+             XPcdata, XExpTag, XChildTag, CorePragma, SCCPragma, GenPragma, Proc,
+             LeftArrApp, RightArrApp, LeftArrHighApp, RightArrHighApp, ArrOp, LCase #-}
+#endif
+
 -- ** `H.XName`
 type XName = H.XName ()
 pattern XName a = H.XName () (a :: String) :: XName
 pattern XDomName a b = H.XDomName () (a :: String) (b :: String) :: XName
 
+#if MIN_VERSION_GLASGOW_HASKELL(8,2,1,0)
+{-# COMPLETE XName, XDomName #-}
+#endif
+
 -- ** `H.XAttr`
 type XAttr = H.XAttr ()
 pattern XAttr a b = H.XAttr () (a :: XName) (b :: Exp) :: XAttr
+
+#if MIN_VERSION_GLASGOW_HASKELL(8,2,1,0)
+{-# COMPLETE XAttr #-}
+#endif
 
 -- ** `H.Bracket`
 type Bracket = H.Bracket ()
@@ -505,6 +750,10 @@ pattern PatBracket a = H.PatBracket () (a :: Pat) :: Bracket
 pattern TypeBracket a = H.TypeBracket () (a :: Type) :: Bracket
 pattern DeclBracket a = H.DeclBracket () (a :: [Decl]) :: Bracket
 
+#if MIN_VERSION_GLASGOW_HASKELL(8,2,1,0)
+{-# COMPLETE ExpBracket, TExpBracket, PatBracket, TypeBracket, DeclBracket #-}
+#endif
+
 -- ** `H.Splice`
 type Splice = H.Splice ()
 pattern IdSplice a = H.IdSplice () (a :: String) :: Splice
@@ -512,11 +761,19 @@ pattern TIdSplice a = H.TIdSplice () (a :: String) :: Splice
 pattern ParenSplice a = H.ParenSplice () (a :: Exp) :: Splice
 pattern TParenSplice a = H.TParenSplice () (a :: Exp) :: Splice
 
+#if MIN_VERSION_GLASGOW_HASKELL(8,2,1,0)
+{-# COMPLETE IdSplice, TIdSplice, ParenSplice, TParenSplice #-}
+#endif
+
 -- ** `H.Safety`
 type Safety = H.Safety ()
 pattern PlayRisky = H.PlayRisky () :: Safety
 pattern PlaySafe a = H.PlaySafe () (a :: Bool) :: Safety
 pattern PlayInterruptible = H.PlayInterruptible () :: Safety
+
+#if MIN_VERSION_GLASGOW_HASKELL(8,2,1,0)
+{-# COMPLETE PlayRisky, PlaySafe, PlayInterruptible #-}
+#endif
 
 -- ** `H.CallConv`
 type CallConv = H.CallConv ()
@@ -529,11 +786,19 @@ pattern Js = H.Js () :: CallConv
 pattern JavaScript = H.JavaScript () :: CallConv
 pattern CApi = H.CApi () :: CallConv
 
+#if MIN_VERSION_GLASGOW_HASKELL(8,2,1,0)
+{-# COMPLETE StdCall, CCall, CPlusPlus, DotNet, Jvm, Js, JavaScript, CApi #-}
+#endif
+
 -- ** `H.ModulePragma`
 type ModulePragma = H.ModulePragma ()
 pattern LanguagePragma a = H.LanguagePragma () (a :: [Name]) :: ModulePragma
 pattern OptionsPragma a b = H.OptionsPragma () (a :: (Maybe Tool)) (b :: String) :: ModulePragma
 pattern AnnModulePragma a = H.AnnModulePragma () (a :: Annotation) :: ModulePragma
+
+#if MIN_VERSION_GLASGOW_HASKELL(8,2,1,0)
+{-# COMPLETE LanguagePragma, OptionsPragma, AnnModulePragma #-}
+#endif
 
 -- skipped: data Tool
 
@@ -546,24 +811,44 @@ pattern Overlaps = H.Overlaps () :: Overlap
 pattern Overlappable = H.Overlappable () :: Overlap
 pattern Incoherent = H.Incoherent () :: Overlap
 
+#if MIN_VERSION_GLASGOW_HASKELL(8,2,1,0)
+{-# COMPLETE NoOverlap, Overlap, Overlapping, Overlaps, Overlappable, Incoherent #-}
+#endif
+
 -- ** `H.Activation`
 type Activation = H.Activation ()
 pattern ActiveFrom a = H.ActiveFrom () (a :: Int) :: Activation
 pattern ActiveUntil a = H.ActiveUntil () (a :: Int) :: Activation
 
+#if MIN_VERSION_GLASGOW_HASKELL(8,2,1,0)
+{-# COMPLETE ActiveFrom, ActiveUntil #-}
+#endif
+
 -- ** `H.Rule`
 type Rule = H.Rule ()
 pattern Rule a b c d e = H.Rule () (a :: String) (b :: (Maybe Activation)) (c :: (Maybe [RuleVar])) (d :: Exp) (e :: Exp) :: Rule
+
+#if MIN_VERSION_GLASGOW_HASKELL(8,2,1,0)
+{-# COMPLETE Rule #-}
+#endif
 
 -- ** `H.RuleVar`
 type RuleVar = H.RuleVar ()
 pattern RuleVar a = H.RuleVar () (a :: Name) :: RuleVar
 pattern TypedRuleVar a b = H.TypedRuleVar () (a :: Name) (b :: Type) :: RuleVar
 
+#if MIN_VERSION_GLASGOW_HASKELL(8,2,1,0)
+{-# COMPLETE RuleVar, TypedRuleVar #-}
+#endif
+
 -- ** `H.WarningText`
 type WarningText = H.WarningText ()
 pattern DeprText a = H.DeprText () (a :: String) :: WarningText
 pattern WarnText a = H.WarnText () (a :: String) :: WarningText
+
+#if MIN_VERSION_GLASGOW_HASKELL(8,2,1,0)
+{-# COMPLETE DeprText, WarnText #-}
+#endif
 
 -- ** `H.Pat`
 type Pat = H.Pat ()
@@ -592,9 +877,19 @@ pattern PSplice a = H.PSplice () (a :: Splice) :: Pat
 pattern PQuasiQuote a b = H.PQuasiQuote () (a :: String) (b :: String) :: Pat
 pattern PBangPat a = H.PBangPat () (a :: Pat) :: Pat
 
+#if MIN_VERSION_GLASGOW_HASKELL(8,2,1,0)
+{-# COMPLETE PVar, PLit, PNPlusK, PInfixApp, PApp, PTuple, PUnboxedSum, PList, PParen,
+             PRec, PAsPat, PWildCard, PIrrPat, PatTypeSig, PViewPat, PRPat, PXTag,
+             PXETag, PXPcdata, PXPatTag, PXRPats, PSplice, PQuasiQuote, PBangPat #-}
+#endif
+
 -- ** `H.PXAttr`
 type PXAttr = H.PXAttr ()
 pattern PXAttr a b = H.PXAttr () (a :: XName) (b :: Pat) :: PXAttr
+
+#if MIN_VERSION_GLASGOW_HASKELL(8,2,1,0)
+{-# COMPLETE PXAttr #-}
+#endif
 
 -- ** `H.RPatOp`
 type RPatOp = H.RPatOp ()
@@ -604,6 +899,10 @@ pattern RPPlus = H.RPPlus () :: RPatOp
 pattern RPPlusG = H.RPPlusG () :: RPatOp
 pattern RPOpt = H.RPOpt () :: RPatOp
 pattern RPOptG = H.RPOptG () :: RPatOp
+
+#if MIN_VERSION_GLASGOW_HASKELL(8,2,1,0)
+{-# COMPLETE RPStar, RPStarG, RPPlus, RPPlusG, RPOpt, RPOptG #-}
+#endif
 
 -- ** `H.RPat`
 type RPat = H.RPat ()
@@ -616,11 +915,19 @@ pattern RPAs a b = H.RPAs () (a :: Name) (b :: RPat) :: RPat
 pattern RPParen a = H.RPParen () (a :: RPat) :: RPat
 pattern RPPat a = H.RPPat () (a :: Pat) :: RPat
 
+#if MIN_VERSION_GLASGOW_HASKELL(8,2,1,0)
+{-# COMPLETE RPOp, RPEither, RPSeq, RPGuard, RPCAs, RPAs, RPParen, RPPat #-}
+#endif
+
 -- ** `H.PatField`
 type PatField = H.PatField ()
 pattern PFieldPat a b = H.PFieldPat () (a :: QName) (b :: Pat) :: PatField
 pattern PFieldPun a = H.PFieldPun () (a :: QName) :: PatField
 pattern PFieldWildcard = H.PFieldWildcard () :: PatField
+
+#if MIN_VERSION_GLASGOW_HASKELL(8,2,1,0)
+{-# COMPLETE PFieldPat, PFieldPun, PFieldWildcard #-}
+#endif
 
 -- ** `H.Stmt`
 type Stmt = H.Stmt ()
@@ -628,6 +935,10 @@ pattern Generator a b = H.Generator () (a :: Pat) (b :: Exp) :: Stmt
 pattern Qualifier a = H.Qualifier () (a :: Exp) :: Stmt
 pattern LetStmt a = H.LetStmt () (a :: Binds) :: Stmt
 pattern RecStmt a = H.RecStmt () (a :: [Stmt]) :: Stmt
+
+#if MIN_VERSION_GLASGOW_HASKELL(8,2,1,0)
+{-# COMPLETE Generator, Qualifier, LetStmt, RecStmt #-}
+#endif
 
 -- ** `H.QualStmt`
 type QualStmt = H.QualStmt ()
@@ -638,15 +949,27 @@ pattern GroupBy a = H.GroupBy () (a :: Exp) :: QualStmt
 pattern GroupUsing a = H.GroupUsing () (a :: Exp) :: QualStmt
 pattern GroupByUsing a b = H.GroupByUsing () (a :: Exp) (b :: Exp) :: QualStmt
 
+#if MIN_VERSION_GLASGOW_HASKELL(8,2,1,0)
+{-# COMPLETE QualStmt, ThenTrans, ThenBy, GroupBy, GroupUsing, GroupByUsing #-}
+#endif
+
 -- ** `H.FieldUpdate`
 type FieldUpdate = H.FieldUpdate ()
 pattern FieldUpdate a b = H.FieldUpdate () (a :: QName) (b :: Exp) :: FieldUpdate
 pattern FieldPun a = H.FieldPun () (a :: QName) :: FieldUpdate
 pattern FieldWildcard = H.FieldWildcard () :: FieldUpdate
 
+#if MIN_VERSION_GLASGOW_HASKELL(8,2,1,0)
+{-# COMPLETE FieldUpdate, FieldPun, FieldWildcard #-}
+#endif
+
 -- ** `H.Alt`
 type Alt = H.Alt ()
 pattern Alt a b c = H.Alt () (a :: Pat) (b :: Rhs) (c :: (Maybe Binds)) :: Alt
+
+#if MIN_VERSION_GLASGOW_HASKELL(8,2,1,0)
+{-# COMPLETE Alt #-}
+#endif
 
 -- * Functions
 


### PR DESCRIPTION
This PR fixes #9. It adds `COMPLETE` pragmas for every data type where pattern synonyms are used, provided the GHC version is 8.2.1 or above (which is when the pragma was introduced afaict). It also adds code to generate these pragmas alongside the pattern generation in `Gen.hs`.